### PR TITLE
Remove dev flag for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Mock your eloquent queries without the repository pattern.
 ## Installation
 You can **install** the package via composer:
 ```bash
-composer require imanghafoori/eloquent-mockery --dev
+composer require imanghafoori/eloquent-mockery
 ```
 
 ## Usage:


### PR DESCRIPTION
When installing deps in a production environment, the dev dependencies are often not included (e..g Heroku)

However to use this package we need to include the trait in the models which is in our production code. 

Ironically, most tests will still pass because the test deps are included when running tests...

But when running on prod, if the dev dependencies aren't included, then this causes an exception saying `Trait "Imanghafoori\EloquentMockery\MockableModel" not found`