### PR TITLE
update compileTableExists definition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,29 +18,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
-        laravel: [^6.0, ^7.0, ^8.0, ^9.0, ^10.0]
-        exclude:
-          - php: 7.2
-            laravel: ^8.0
-          - php: 7.2
-            laravel: ^9.0
-          - php: 7.2
-            laravel: ^10.0
-          - php: 7.3
-            laravel: ^9.0
-          - php: 7.3
-            laravel: ^10.0
-          - php: 7.4
-            laravel: ^9.0
-          - php: 7.4
-            laravel: ^10.0
-          - php: 8.0
-            laravel: ^10.0
-          - php: 8.1
-            laravel: ^6.0
-          - php: 8.1
-            laravel: ^7.0
+        php: [8.2, 8.3]
+        laravel: [^11.0]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php" : "^7.2|^8.0",
-        "illuminate/database": "5.*|6.*|7.*|8.*|9.*|10.*|11.*",
-        "illuminate/events": "5.*|6.*|7.*|8.*|9.*|10.*|11.*"
+        "illuminate/database": "11.*",
+        "illuminate/events": "11.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.20|^8.5.28|^9.5",

--- a/src/FakeSchemaGrammar.php
+++ b/src/FakeSchemaGrammar.php
@@ -153,6 +153,7 @@ class FakeSchemaGrammar extends SchemaGrammar
     {
         return $this->stringy([
             'type' => 'tableExists',
+            'args' => ['database' => $database, 'table' => $table],
             'sql' => parent::compileTableExists($database, $table),
         ]);
     }

--- a/src/FakeSchemaGrammar.php
+++ b/src/FakeSchemaGrammar.php
@@ -149,11 +149,11 @@ class FakeSchemaGrammar extends SchemaGrammar
         return parent::compileDropAllTables($tables);
     }
 
-    public function compileTableExists()
+    public function compileTableExists($database, $table)
     {
         return $this->stringy([
             'type' => 'tableExists',
-            'sql' => parent::compileTableExists(),
+            'sql' => parent::compileTableExists($database, $table),
         ]);
     }
 


### PR DESCRIPTION
Within https://github.com/laravel/framework/pull/53006 definition of compileTableExists method has changed - this PR aligns the definition to the change.

This also means that `5.*|6.*|7.*|8.*|9.*|10.*` require for `illuminate/database` will no longer apply though. 

Think you could do `__call` like this for this (and other methods like `compileColumnListing`, `compileGetAllTables` etc)
```
public function __call(string $name, array $arguments):mixed {
   if (method_exists(get_parent_class($this), $name))
   return $this->stringy([
      'type' => $name,
      'args' => $arguments,
      'sql' => parent::$name($arguments)
  ]);

  throw RuntimeException(sprintf("Method %s does not exist on parent", $name));
}
```
so that support for different versions still remains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved table existence checking mechanism by adding database and table parameters to the schema grammar method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->