### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php" : "^7.2|^8.0",
-        "illuminate/database": "5.*|6.*|7.*|8.*|9.*|10.*|11.*",
-        "illuminate/events": "5.*|6.*|7.*|8.*|9.*|10.*|11.*"
+        "illuminate/database": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
+        "illuminate/events": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.20|^8.5.28|^9.5",

--- a/src/FakeConnection.php
+++ b/src/FakeConnection.php
@@ -13,11 +13,11 @@ class FakeConnection extends Connection implements ConnectionInterface
     public static function resolve($connection = null, $db = '', $prefix = '', $config = ['name' => 'arrayDB'])
     {
         $fakeConnection = new FakeConnection(function () {
-            return new FakePDO;
+            return new FakePDO();
         }, $db, $prefix, $config);
 
-        $fakeConnection->setQueryGrammar(new FakeGrammar);
-        
+        $fakeConnection->setQueryGrammar(new FakeGrammar($fakeConnection));
+
         return $fakeConnection;
     }
 
@@ -39,13 +39,15 @@ class FakeConnection extends Connection implements ConnectionInterface
     public function query()
     {
         return new FakeQueryBuilder(
-            $this, $this->getQueryGrammar(), $this->getPostProcessor()
+            $this,
+            $this->getQueryGrammar(),
+            $this->getPostProcessor()
         );
     }
 
     protected function getDefaultQueryGrammar()
     {
-        return new FakeGrammar;
+        return new FakeGrammar($this);
     }
 
     public function statement($query, $bindings = [])
@@ -53,12 +55,11 @@ class FakeConnection extends Connection implements ConnectionInterface
         if (is_object($query)) {
             $query = $query->data;
         } else {
-            
         }
         if (FakeSchemaGrammar::$query && is_string($query)) {
             $payload = array_shift(FakeSchemaGrammar::$query);
             $query = [
-                'sql' => $query,
+                'sql'  => $query,
                 'args' => $payload['args'] ?? null,
                 'type' => $payload['type'],
             ];

--- a/src/FakeDB.php
+++ b/src/FakeDB.php
@@ -63,7 +63,7 @@ class FakeDB
 
     public static function table($table)
     {
-        return new class ($table) {
+        return new class($table) {
             private $table;
 
             public function __construct($table)
@@ -79,7 +79,7 @@ class FakeDB
             public function allRows()
             {
                 $rows = [];
-                foreach((FakeDB::$fakeRows[$this->table] ?? []) as $i => $row) {
+                foreach ((FakeDB::$fakeRows[$this->table] ?? []) as $i => $row) {
                     $rows[$i] = $row[$this->table];
                 }
 
@@ -189,12 +189,12 @@ class FakeDB
 
                 $result = 0;
 
-                if (! is_string($prop) && is_callable($prop)) {
+                if (!is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);
                 } else {
                     $values = [data_get($a, $prop), data_get($b, $prop)];
 
-                    if (! $ascending) {
+                    if (!$ascending) {
                         $values = array_reverse($values);
                     }
 
@@ -241,7 +241,7 @@ class FakeDB
         return $collection->map(function ($item) use ($columns, $aliases, $_table) {
             if ($columns !== ['*']) {
                 foreach ($columns as $i => $col) {
-                    ! Str::contains($col, '.') && $columns[$i] = $_table.'.'.$col;
+                    !Str::contains($col, '.') && $columns[$i] = $_table.'.'.$col;
                 }
                 $newItem = [];
                 foreach ($columns as $col) {
@@ -362,7 +362,7 @@ class FakeDB
     {
         $pattern = str_replace('%', '.*', preg_quote($pattern, '/'));
 
-        return (bool) (preg_match("/^{$pattern}$/i", data_get($item, $value) ?? ''));
+        return (bool) preg_match("/^{$pattern}$/i", data_get($item, $value) ?? '');
     }
 
     public static function whereColumn($where, $row)
@@ -436,7 +436,7 @@ class FakeDB
 
     public static function prefixColumn($column, $mainTable, $joins)
     {
-        if (! Str::contains($column, '.') && ! isset(FakeDB::$fakeRows[$mainTable][0][$mainTable][$column]) && $joins) {
+        if (!Str::contains($column, '.') && !isset(FakeDB::$fakeRows[$mainTable][0][$mainTable][$column]) && $joins) {
             foreach ($joins as $joined) {
                 $table = $joined->table;
                 if (isset(FakeDB::$fakeRows[$table][0][$table][$column])) {
@@ -445,7 +445,7 @@ class FakeDB
             }
         }
 
-        if (! Str::contains($column, '.')) {
+        if (!Str::contains($column, '.')) {
             $column = $mainTable.'.'.$column;
         }
 
@@ -505,7 +505,7 @@ class FakeDB
 
         $orderBy && ($collection = self::sortRows($collection, $orderBy));
 
-        if (! FakeDB::$ignoreWheres) {
+        if (!FakeDB::$ignoreWheres) {
             $collection = FakeDB::applyWheres($query, $collection);
         }
 
@@ -520,11 +520,11 @@ class FakeDB
 
     public static function sortRows(Collection $collection, $orderBy)
     {
-        if (! $orderBy) {
+        if (!$orderBy) {
             return $collection;
         }
         if (count($orderBy) === 1 && is_object($orderBy[0]['sql'] ?? '')) {
-            $data = ($orderBy[0]['sql'])->data;
+            $data = $orderBy[0]['sql']->data;
             if ($data['type'] === 'random') {
                 return $collection->shuffle((int) $data['seed']);
             }
@@ -718,7 +718,7 @@ class FakeDB
 
     public static function insertGetId(array $values, $table)
     {
-        if (! Arr::isAssoc($values)) {
+        if (!Arr::isAssoc($values)) {
             foreach ($values as $value) {
                 self::insertGetId($value, $table);
             }
@@ -726,7 +726,7 @@ class FakeDB
             return true;
         }
 
-        if (! isset($values['id'])) {
+        if (!isset($values['id'])) {
             $values['id'] = (FakeDB::$tables[$table]['latestRowId'] ?? 0) + 1;
         }
 

--- a/src/FakeSchemaGrammar.php
+++ b/src/FakeSchemaGrammar.php
@@ -28,7 +28,7 @@ class FakeSchemaGrammar extends SchemaGrammar
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         self::keepData('change', [$blueprint, $command, $connection]);
-        
+
         return parent::compileChange($blueprint, $command, $connection);
     }
 
@@ -41,17 +41,14 @@ class FakeSchemaGrammar extends SchemaGrammar
 
     public function compileKey(Blueprint $blueprint, Fluent $command, $type)
     {
-        
     }
 
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
     {
-        
     }
 
     public function compileForeign(Blueprint $blueprint, Fluent $command)
     {
-        
     }
 
     public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
@@ -63,7 +60,6 @@ class FakeSchemaGrammar extends SchemaGrammar
 
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        
     }
 
     public function compileRename(Blueprint $blueprint, Fluent $command)
@@ -91,17 +87,25 @@ class FakeSchemaGrammar extends SchemaGrammar
     {
         return $this->stringy([
             'type' => 'columnListing',
-            'sql' => parent::compileColumnListing(),
+            'sql'  => parent::compileColumnListing(),
         ]);
 
         return parent::compileColumnListing();
+    }
+
+    public function compileTableListing($schema = null, $schemaQualified = true)
+    {
+        return $this->stringy([
+            'type' => 'getAllTables',
+            'sql'  => parent::compileTableListing($schema, $schemaQualified),
+        ]);
     }
 
     public function compileGetAllTables()
     {
         return $this->stringy([
             'type' => 'getAllTables',
-            'sql' => parent::compileGetAllTables(),
+            'sql'  => parent::compileGetAllTables(),
         ]);
     }
 
@@ -110,7 +114,7 @@ class FakeSchemaGrammar extends SchemaGrammar
         return $this->stringy([
             'type' => 'columns',
             'args' => ['database' => $database, 'table' => $table],
-            'sql' => parent::compileColumns($database, $table),
+            'sql'  => parent::compileColumns($database, $table),
         ]);
     }
 
@@ -153,14 +157,13 @@ class FakeSchemaGrammar extends SchemaGrammar
     {
         return $this->stringy([
             'type' => 'tableExists',
-            'sql' => parent::compileTableExists(),
+            'sql'  => parent::compileTableExists(),
         ]);
     }
 
     private function stringy(array $data)
     {
-        return new class ($data){
-
+        return new class($data) {
             public $data;
 
             public function __construct($data)


### PR DESCRIPTION
## Summary by Sourcery

Add support for Laravel 12 by updating dependencies and adjusting related code.

Enhancements:
- Inject the `FakeConnection` instance into the `FakeGrammar` constructor.
- Add the `compileTableListing` method to `FakeSchemaGrammar`.
- Apply minor code style fixes and remove empty method bodies.

Build:
- Update `illuminate/database` and `illuminate/events` dependency constraints in `composer.json` to include `12.*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a method to support table listing functionality in schema operations.

- **Style**
  - Improved code formatting and consistency across multiple files, including whitespace cleanup and standardized spacing.

- **Chores**
  - Updated dependency version constraints to support newer versions of required packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->