### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3]
+        php: [8.4]
     name: PHP ${{ matrix.php }} - OS ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
-        laravel: [^11.0]
+        php: [7.2, 8.2, 8.3, 8.4, 8.5]
+        laravel: [^11.0, ^12.0, ^13.0]
+        exclude:
+          - php: 7.2
+            laravel: ^13.0
+          - php: 8.2
+            laravel: ^13.0
+        
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         }
     ],
     "require": {
-        "php" : "^7.2|^8.0",
-        "illuminate/database": "11.*|12.*",
-        "illuminate/events": "11.*|12.*"
+        "php" : "^7.2 || >=8.2",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/events": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5.20|^8.5.28|^9.5",
-        "imanghafoori/php-imports-analyzer": "^1.0.2",
-        "symfony/var-dumper" : "3.*|4.*|5.*"
+        "phpunit/phpunit": "^10.0|^11.0",
+        "robiningelbrecht/phpunit-coverage-tools": "^1.10"
+        "symfony/var-dumper" : "@stable"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0|^11.0|^12.0",
-        "robiningelbrecht/phpunit-coverage-tools": "^1.10"
+        "robiningelbrecht/phpunit-coverage-tools": "^1.10",
         "symfony/var-dumper" : "^6.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         }
     ],
     "require": {
-        "php" : "^7.2 || >=8.2",
+        "php" : "^8.0",
         "illuminate/database": "^11.0|^12.0|^13.0",
         "illuminate/events": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "robiningelbrecht/phpunit-coverage-tools": "^1.10"
-        "symfony/var-dumper" : "@stable"
+        "symfony/var-dumper" : "^6.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary by Sourcery

Add support for Laravel 13 while updating platform and tooling requirements.

Build:
- Broaden framework constraints to support illuminate/database and illuminate/events v13 and adjust PHP version requirements.
- Update dev dependencies to newer PHPUnit and coverage tooling and relax symfony/var-dumper to track stable releases.
- Bump CI workflow to run code coverage on PHP 8.4.